### PR TITLE
Inherit existing no_automatic_type_field! setting from parent

### DIFF
--- a/lib/lightweight_serializer/serializer.rb
+++ b/lib/lightweight_serializer/serializer.rb
@@ -13,6 +13,7 @@ module LightweightSerializer
       base.__lws_serialized_type = __lws_serialized_type.dup
       base.__lws_serialized_class = __lws_serialized_class.dup
       base.__lws_allowed_options = __lws_allowed_options.deep_dup || Set.new
+      base.__lws_skip_automatic_type_field = !!__lws_skip_automatic_type_field
       super
     end
 
@@ -112,6 +113,7 @@ module LightweightSerializer
 
       attr_writer :__lws_defined_attributes,
                   :__lws_defined_nested_serializers,
+                  :__lws_skip_automatic_type_field,
                   :__lws_allowed_options,
                   :__lws_serialized_type,
                   :__lws_serialized_class

--- a/spec/lib/lightweight_serializer/serializer_spec.rb
+++ b/spec/lib/lightweight_serializer/serializer_spec.rb
@@ -109,6 +109,8 @@ RSpec.describe LightweightSerializer::Serializer do
       serializes model: 'SuperDuperTestModel'
     end
 
+    inherited_super_duper_test_serializer_without_type_class = Class.new(super_duper_test_serializer_without_type_class)
+
     stub_const('AddressSerializer', address_serializer_class)
     stub_const('PersonSerializer', person_serializer_class)
     stub_const('ErrorSerializer', error_serializer_class)
@@ -131,6 +133,7 @@ RSpec.describe LightweightSerializer::Serializer do
     stub_const('SuperDuperTestSerializer', super_duper_test_serializer_class)
     stub_const('InheritedSuperDuperTestSerializer', inherited_super_duper_test_serializer_class)
     stub_const('SuperDuperTestSerializerWithoutTypeField', super_duper_test_serializer_without_type_class)
+    stub_const('InheritedSuperDuperTestSerializerWithoutTypeField', inherited_super_duper_test_serializer_without_type_class)
     stub_const('SomeTestModel', test_model_class)
   end
 
@@ -413,6 +416,11 @@ RSpec.describe LightweightSerializer::Serializer do
     context 'type field generation' do
       it 'does not generate a type field, when no_automatic_type_field! is used' do
         serializer = SuperDuperTestSerializerWithoutTypeField.new(SomeTestModel.new)
+        expect(serializer.as_json[:data]).not_to have_key(:type)
+      end
+
+      it 'does not generate a type field on inherited classes when no_automatic_type_field! is used on the parent' do
+        serializer = InheritedSuperDuperTestSerializerWithoutTypeField.new(SomeTestModel.new)
         expect(serializer.as_json[:data]).not_to have_key(:type)
       end
 


### PR DESCRIPTION
:wave:,

while using this gem, I've stumbled across something that could be perceived as bug or maybe it's intended.

Given this set of serializers:

```rb
class WithoutTypeSerializer < LightweightSerializer::Serializer
  no_automatic_type_field!
end

class ModelSerializer < WithoutTypeSerializer
end
```

When I serialize anything with the `ModelSerializer`, it will always include the `type` attribute, even though I was expecting the type attribute to be not there.

A fix is easy enough, but as I've said, I'm not sure if this is the intended behaviour or not and I wanted to clarify first with you :)

This PR fixes that "bug", but I'm happy to close it if you say this is intended behaviour (which we then should probably document somewhere)