### PR TITLE
Support collection serialization of ActiveModel::Errors

### DIFF
--- a/lib/lightweight_serializer/serializer.rb
+++ b/lib/lightweight_serializer/serializer.rb
@@ -2,6 +2,7 @@
 
 require 'set'
 require 'active_record'
+require 'active_model'
 
 module LightweightSerializer
   class Serializer
@@ -162,7 +163,9 @@ module LightweightSerializer
     def as_json(*_args)
       result = if @object_or_collection.nil?
                  nil
-               elsif @object_or_collection.is_a?(Array) || @object_or_collection.is_a?(ActiveRecord::Relation)
+               elsif @object_or_collection.is_a?(Array) ||
+                     @object_or_collection.is_a?(ActiveRecord::Relation) ||
+                     @object_or_collection.is_a?(ActiveModel::Errors)
                  @object_or_collection.map do |object|
                    serialized_object(object).tap do |hash|
                      hash[:type] = type_data(object) unless self.class.__lws_skip_automatic_type_field

--- a/spec/lib/lightweight_serializer/serializer_spec.rb
+++ b/spec/lib/lightweight_serializer/serializer_spec.rb
@@ -413,6 +413,19 @@ RSpec.describe LightweightSerializer::Serializer do
       end
     end
 
+    describe 'when called with ActiveModel:Errors' do
+      let(:errors) do
+        ActiveModel::Errors.new(Class.new).tap do |errors|
+          errors.add(:base, 'Something went wrong')
+        end
+      end
+      let(:error_serializer) { ErrorSerializer.new(errors) }
+
+      it 'returns a hash with a data root and an array of elements' do
+        expect(error_serializer.as_json).to be_kind_of(Array)
+      end
+    end
+
     context 'type field generation' do
       it 'does not generate a type field, when no_automatic_type_field! is used' do
         serializer = SuperDuperTestSerializerWithoutTypeField.new(SomeTestModel.new)


### PR DESCRIPTION
We've ran into issues when trying to serialize ActiveModel::Errors, thinking they'd be handled just like any other collection.

This adds support for it, nothing too fancy. I'm just wondering if we should use duck typing here and rely on `is_a?(Enumerable)` instead, but a quick check yielded other problems and I wanted to check with you first what you prefer, since I guess that there's a good reason for being explicit there.