### PR TITLE
Add support for serialization of hashes

### DIFF
--- a/lib/lightweight_serializer/serializer.rb
+++ b/lib/lightweight_serializer/serializer.rb
@@ -270,6 +270,8 @@ module LightweightSerializer
     def block_or_attribute_from_object(object, attribute_config)
       if attribute_config.block
         instance_exec(object, &attribute_config.block)
+      elsif object.is_a? Hash
+        object[attribute_config.attr_name]
       else
         object.public_send(attribute_config.attr_name)
       end

--- a/lib/lightweight_serializer/serializer.rb
+++ b/lib/lightweight_serializer/serializer.rb
@@ -271,7 +271,7 @@ module LightweightSerializer
       if attribute_config.block
         instance_exec(object, &attribute_config.block)
       elsif object.is_a? Hash
-        object[attribute_config.attr_name]
+        object.fetch(attribute_config.attr_name)
       else
         object.public_send(attribute_config.attr_name)
       end

--- a/spec/lib/lightweight_serializer/serializer_spec.rb
+++ b/spec/lib/lightweight_serializer/serializer_spec.rb
@@ -430,6 +430,10 @@ RSpec.describe LightweightSerializer::Serializer do
         expect(drink_array_serializer.as_json[:data]).to be_kind_of(Array)
         expect(drink_array_serializer.as_json[:data].count).to eq(2)
       end
+
+      it 'raises when an attribute is missing' do
+        expect { DrinkSerializer.new({ brand: 'Coca Cola' }).as_json }.to raise_error KeyError
+      end
     end
 
     describe 'when called with ActiveModel:Errors' do

--- a/spec/lib/lightweight_serializer/serializer_spec.rb
+++ b/spec/lib/lightweight_serializer/serializer_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe LightweightSerializer::Serializer do
   end
 
   let(:drink_model) { DrinkModel.new(brand: 'Coca Cola', name: 'Coke Zero', serving_size: '500 ml') }
+  let(:drink_hash) { { brand: 'Coca Cola', name: 'Coke Zero', serving_size: '500 ml' } }
   let(:person_model) do
     OpenStruct.new(first_name: 'John', middle_name: 'Eric', last_name: 'Doe', phone_number: '16465551234',
                    addresses: [address_2_model, address_1_model], favorite_drink: drink_model, errors: [])
@@ -410,6 +411,24 @@ RSpec.describe LightweightSerializer::Serializer do
           expect(error_serializer.as_json).to be_kind_of(Array)
           expect(error_serializer.as_json.count).to eq(errors.count)
         end
+      end
+    end
+
+    describe 'when called on a hash' do
+      let(:drink_serializer) { DrinkSerializer.new(drink_hash) }
+      let(:drink_array_serializer) { DrinkSerializer.new([drink_hash, drink_hash]) }
+
+      it 'returns a hash with a data root' do
+        expect(drink_serializer.as_json).to have_key(:data)
+        expect(drink_serializer.as_json[:data]).to eq(
+          { brand: 'Coca Cola', name: 'Coke Zero', type: :drink }
+        )
+      end
+
+      it 'returns an array of elements' do
+        expect(drink_array_serializer.as_json).to have_key(:data)
+        expect(drink_array_serializer.as_json[:data]).to be_kind_of(Array)
+        expect(drink_array_serializer.as_json[:data].count).to eq(2)
       end
     end
 


### PR DESCRIPTION
Currently LWS only supports the serialization of objects. Often it is easier to use hashes though, especially for small data structures.

For example, we'd like to do the following:

```ruby
countries = ISO3166::Country.all.map do |country|
  {
    code: country.alpha2,
    label: country.translation(I18n.locale)
  }
end

render json: countries, serializer: CountrySerializer
```

```ruby
class CountrySerializer < ApplicationSerializer
  attribute :code
  attribute :label
end
```

If you currently try to serialize a hash:

```
NoMethodError:
       undefined method `code' for #<Hash:0x00005578e8dd3450>
```

This PR solves the above error. So `CountrySerializer.new({code: 'DE', label: 'Germany'})` then works fine.