### PR TITLE
`README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # LightweightSerializer [![CI Status](https://github.com/ioki-mobility/lightweight_serializer/actions/workflows/main.yml/badge.svg)](https://github.com/ioki-mobility/lightweight_serializer/actions/workflows/main.yml)
 
-LightweightSerializer is a gem that allows you to write serializers for your API, to define your JSON models. It is highly
-opinionated, and tries to use as little magic as possible, but instead requires you to explicitly write what you want to
-do.
+LightweightSerializer is a gem that allows you to write serializers for your API, to define your JSON models. It is highly opinionated, and tries to use as little magic as possible, but instead requires you to explicitly write what you want to do.
 
-As an addition, this gem also provides easy ways to generate [OpenAPI 3](https://swagger.io/specification/) compatible
-specification for your API endpoints.
+As an addition, this gem also provides easy ways to generate an [OpenAPI 3](https://swagger.io/specification/) compatible specification for your API endpoints.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's `Gemfile`:
 
 ```ruby
 gem 'lightweight_serializer'
@@ -21,9 +18,21 @@ And then execute:
 
 ## Usage
 
-To create a serializer, create a new file in your `app/serializers/` folder. Let's assume we have a nice blog:
+Let us assume a blog data structure. Given the following serializers:
 
 ```ruby
+class CommentSerializer < LightweightSerializer::Serializer
+  attribute :content
+  attribute :name do |object|
+    object.first_name + " " + object.last_name
+  end
+end
+
+class UserSerializer < LightweightSerializer::Serializer
+  attribute :email
+  attribute :name
+end
+
 class PostSerializer < LightweightSerializer::Serializer
   attribute :title
   attribute :content
@@ -32,14 +41,491 @@ class PostSerializer < LightweightSerializer::Serializer
 
   nested :author, serializer: UserSerializer
 end
+```
 
-class CommentSerializer < LightweightSerializer::Serializer
-  attribute :content
-  attribute :name do |object|
-    object.first_name + " " + object.last_name
-  end
+Serialize it with:
+
+```ruby
+post = {title: 'Using LightweightSerializer', content: 'Lorem ipsum', comments: [OpenStruct.new({content: 'Great post!', first_name: 'Sarah', last_name: 'Muster'})], author: {email: 'muster@example.com', name: 'Dominik Muster'}}
+
+serializer = PostSerializer.new(post)
+serializer.as_json
+```
+
+This outputs a Ruby `Hash`:
+
+```ruby
+{
+  data: {
+    title: "Using LightweightSerializer",
+    content: "Lorem ipsum",
+    comments: [
+      {
+        content: "Great post!",
+        name: "Sarah Muster",
+        type: "open_struct"
+      }
+    ],
+    author: {
+      email: "muster@example.com",
+      name: "Dominik Muster",
+      type: "hash"
+    },
+    type: "hash"
+  }
+}
+```
+
+You can pass any object or a hash to the serializer.
+
+### Serializer DSL
+
+The following DSL can be used within a `LightweightSerializer::Serializer`.
+
+#### `attribute`
+
+Serialize an attribute (same name in the output as in the object):
+
+```ruby
+attribute :name
+```
+
+Serialize an attribute with a different name (outputs `name`, but reads `full_name` from the object):
+
+```ruby
+attribute :name, &:full_name
+```
+
+Note that this is the same as the following. By passing a block, it is possible to include further logic to conclude on the serialized value. The passed `object` in the block is the same as the one the serializer was called with.
+
+```ruby
+attribute(:name) { |object| object.full_name }
+```
+
+Do not forget the parantheses around the attribute name when specifying a block.
+
+This is also required for boolean methods conventionally ending with a `?`:
+
+```ruby
+attribute :admin, &:admin?
+```
+
+Conditionally include specific attributes:
+
+```ruby
+class PostSerializer < LightweightSerializer::Serializer
+  attribute :title # Serialized in any case
+  attribute :state, condition: :admin # Serialized only if `admin` is truthy
+end
+
+PostSerializer.new(post, admin: current_user.admin?)
+```
+
+Move the attribute to a group:
+
+```ruby
+attribute :name, group: :author
+```
+
+`Serializer.new({name: 'Sarah'}).as_json` outputs:
+
+```ruby
+{
+  data: {
+    author: {
+      name: "Sarah"
+    }
+  }
+}
+```
+
+Note that it may be more readable to use `group` directly instead:
+
+```ruby
+group :author do
+  attribute :name
 end
 ```
+
+#### `nested`
+
+Nest another object:
+
+```ruby
+nested :author, serializer: AuthorSerializer
+```
+
+The output would be:
+
+```ruby
+{
+  author: {
+    ...
+  }
+}
+```
+
+`nested` also supports the `group` and `condition` options (cf. `attribute`).
+
+#### `collection`
+
+Serializes an array of a resource:
+
+```ruby
+collection :comments, serializer: CommentSerializer
+```
+
+The output would be:
+
+```ruby
+{
+  comments: [
+    {
+      # first comment
+    },
+    {
+      # second comment
+    }
+  ]
+}
+```
+
+`collection` also supports the `group` and `condition` options (cf. `attribute`).
+
+A hash can be provided to `serializer` to serialize arrays of differing object types (make sure to use the actual `Class` as a hash key - strings are not supported):
+
+```ruby
+TechPost = Struct.new(:title, :technology)
+SciencePost = Struct.new(:title, :field)
+
+class TechPostSerializer < LightweightSerializer::Serializer
+  attribute :title
+  attribute :technology
+end
+
+class SciencePostSerializer < LightweightSerializer::Serializer
+  attribute :title
+  attribute :field
+end
+
+class BlogSerializer < LightweightSerializer::Serializer
+  collection :posts, serializer: {
+    TechPost => TechPostSerializer,
+    SciencePost => SciencePostSerial
+  }
+end
+
+BlogSerializer.new({posts: [
+  TechPost.new('Lorem', 'JS'),
+  SciencePost.new('Ipsum', 'SE')
+]}).as_json
+
+# {
+#   data: {
+#     posts: [
+#       {title: "Lorem", technology: "JS", type: "tech_post"},
+#       {title: "Ipsum", field: "SE", type: "science_post"}
+#     ],
+#     type: "hash"
+#   }
+# }
+```
+
+#### `no_automatic_type_field!`
+
+```ruby
+class PostSerializer < LightweightSerializer::Serializer
+  no_automatic_type_field!
+  attribute :title
+end
+```
+
+Does not write the `type` attribute. The above would output:
+
+```ruby
+{
+  data: {
+    title: '..'
+  }
+}
+```
+
+As opposed to the following if omitting `no_automatic_type_field!`:
+
+```ruby
+{
+  data: {
+    title: '..',
+    type: 'post'
+  }
+}
+```
+
+#### `no_root!`
+
+```ruby
+class PostSerializer < LightweightSerializer::Serializer
+  no_root!
+  attribute :title
+end
+```
+
+Does not write the outer `data` attribute. The above would output:
+
+```ruby
+{
+  title: '..',
+  type: 'post'
+}
+```
+
+As opposed to the following if omitting `no_root!`:
+
+```ruby
+{
+  data: {
+    title: '..',
+    type: 'post'
+  }
+}
+```
+
+#### `group`
+
+Groups one or more attributes in the output nested into the given name:
+
+```ruby
+group :author do
+  attribute :first_name
+  attribute :last_name
+end
+```
+
+This outputs:
+
+```ruby
+{
+  data: {
+    author: {
+      first_name: "Sarah",
+      last_name: "Muster"
+    },
+    type: "hash"
+  }
+}
+```
+
+#### `remove_attribute`
+
+Removes an attribute from the serializer. This is useful when inheriting from a serializer, but not all attributes should be serialized.
+
+```ruby
+class PersonSerializer < LightweightSerializer::Serializer
+  attribute :name
+  attribute :city
+end
+
+class AuthorSerializer < PersonSerializer
+  remove_attribute :city
+end
+
+AuthorSerializer.new({name: 'Sarah Muster', city: 'Musterhausen'}).as_json
+# {
+#   data: {
+#     name: "Sarah Muster",
+#     type: "hash"
+#   }
+# }
+
+PersonSerializer.new({name: 'Sarah Muster', city: 'Musterhausen'}).as_json
+# {
+#   data: {
+#     name: "Sarah Muster",
+#     city: "Musterhausen",
+#     type: "hash"
+#   }
+# }
+```
+
+#### `serializes`
+
+Defines the type being serialized. This is mostly useful when serializing hashes or an `OpenStruct`, as these would otherwise be serialized as `type: "hash"` and `type: "open_struct"`.
+
+```ruby
+serializes type:, model:
+```
+
+`type` should be a symbol or a string and is used exactly as given. It always has precedence over `model`. `model` can be either a `Class` or a string, but `underscore` is called on it.
+
+Example for `type`:
+
+```ruby
+class PostSerializer < LightweightSerializer::Serializer
+  serializes type: 'Post'
+  attribute :title
+end
+
+PostSerializer.new({title: 'Lorem'}).as_json
+# {
+#   data: {
+#     title: "Lorem",
+#     type: "Post"
+#   }
+# }
+```
+
+Example for `model` with a `Class`:
+
+```ruby
+class Post
+end
+
+class PostSerializer < LightweightSerializer::Serializer
+  serializes model: Post
+  attribute :title
+end
+
+PostSerializer.new({title: 'Lorem'}).as_json
+# {
+#   data: {
+#     title: "Lorem",
+#     type: "post"
+#   }
+# }
+```
+
+Example for `model` with a string:
+
+```ruby
+class BlogPostSerializer < LightweightSerializer::Serializer
+  serializes model: 'BlogPost'
+  attribute :title
+end
+
+BlogPostSerializer.new({title: 'Lorem'}).as_json
+# {
+#   data: {
+#     title: "Lorem",
+#     type: "blog_post"
+#   }
+# }
+```
+
+### Options to serializers
+
+Use `skip_root` to avoid `data` to be added:
+
+```ruby
+PostSerializer.new({title: 'Lorem'}, skip_root: true).as_json
+```
+
+This outputs:
+
+```ruby
+{title: "Lorem", type: "hash"}
+```
+
+This has the same effect as adding `no_root!` to the serializer. Note that `no_root!` has always precedence. You cannot readd `data` by specifying `skip_root: false`.
+
+If the `data` attribute is included in the output, you can use `meta` to add any additional information alongside. It is most often used for pagination information, but the content of `meta` is arbitrary.
+
+```ruby
+PostSerializer.new([{title: 'Lorem'}], meta: {page: 1, total: 10}).as_json
+```
+
+Outputs:
+
+```ruby
+{
+  data: [
+    {title: "Lorem", type: "hash"}
+  ],
+  meta: {
+    page: 1, total: 10
+  }
+}
+```
+
+Note that `meta` is ignored when the serializer uses `no_root!`.
+
+### Documentation
+
+Use the following to generate the OpenAPI specification for an object represented by a serializer:
+
+```ruby
+LightweightSerializer::Documentation.new(PostSerializer).openapi_schema
+```
+
+To get any meaningful output, document the attributes in your serializers with the following additional options. Make sure that you put the documentation options after all serializer options.
+
+```
+additionalProperties
+allOf
+anyOf
+default
+deprecated
+description
+enum
+example
+exclusiveMaximum
+exclusiveMinimum
+externalDocs
+format
+items
+maximum
+maxItems
+maxLength
+maxProperties
+minimum
+minItems
+minLength
+minProperties
+multipleOf
+not
+nullable
+oneOf
+pattern
+properties
+readOnly
+required
+title
+type
+uniqueItems
+writeOnly
+xml
+```
+
+Refer to the [OpenAPI specification](https://spec.openapis.org/oas/latest.html) to learn about the accepted values of these options.
+
+### Rails
+
+* Put your serializers in `app/serializers/`.
+* Add an `ApplicationSerializer` to share common options:
+
+    ```ruby
+    class ApplicationSerializer < LightweightSerializer::Serializer
+      no_automatic_type_field!
+    end
+    ```
+
+    Then inherit from it:
+    
+    ```ruby
+    class PostSerializer < ApplicationSerializer
+    end
+    ```
+
+* In a controller action, render JSON as follows:
+
+    ```ruby
+    render json: objects, serializer: PostSerializer`
+    ```
+
+    If you want to serialize without a serializer:
+
+    ```ruby
+    render json: objects, no_serializer: true
+    ```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # LightweightSerializer [![CI Status](https://github.com/ioki-mobility/lightweight_serializer/actions/workflows/main.yml/badge.svg)](https://github.com/ioki-mobility/lightweight_serializer/actions/workflows/main.yml)
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/lightweight_serializer`. To experiment with that code, run `bin/console` for an interactive prompt.
+LightweightSerializer is a gem that allows you to write serializers for your API, to define your JSON models. It is highly
+opinionated, and tries to use as little magic as possible, but instead requires you to explicitly write what you want to
+do.
 
-TODO: Delete this and the text above, and describe your gem
+As an addition, this gem also provides easy ways to generate [OpenAPI 3](https://swagger.io/specification/) compatible
+specification for your API endpoints.
 
 ## Installation
 
@@ -16,13 +19,27 @@ And then execute:
 
     $ bundle install
 
-Or install it yourself as:
-
-    $ gem install lightweight_serializer
-
 ## Usage
 
-TODO: Write usage instructions here
+To create a serializer, create a new file in your `app/serializers/` folder. Let's assume we have a nice blog:
+
+```ruby
+class PostSerializer < LightweightSerializer::Serializer
+  attribute :title
+  attribute :content
+
+  collection :comments, serializer: CommentSerializer
+
+  nested :author, serializer: UserSerializer
+end
+
+class CommentSerializer < LightweightSerializer::Serializer
+  attribute :content
+  attribute :name do |object|
+    object.first_name + " " + object.last_name
+  end
+end
+```
 
 ## Development
 
@@ -32,7 +49,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/lightweight_serializer.
+Bug reports and pull requests are welcome on GitHub at https://github.com/ioki-mobility/lightweight_serializer.
 
 ## License
 

--- a/lib/lightweight_serializer/railtie.rb
+++ b/lib/lightweight_serializer/railtie.rb
@@ -11,7 +11,8 @@ module LightweightSerializer
 
         if options[:serializer].blank? && !options[:no_serializer]
           raise ArgumentError,
-                'You must provide a Serializer class to render JSON or use no_serializer: true option'
+                'You must provide a Serializer class to render JSON (e.g. `serializer: PostSerializer`) \
+                or use no_serializer: true option'
         end
 
         self.content_type = Mime[:json]


### PR DESCRIPTION
Adds usage instruction and examples to the `README`. Supersedes https://github.com/ioki-mobility/lightweight_serializer/pull/1.

Link to rendered README for better reading: https://github.com/metikular/lightweight_serializer/blob/better-readme/README.md

## Caveats

* I didn't document `allow_options`, because I don't understand what it's doing. The serializers filter the options passed to them via `__lws_allowed_options`. Any conditions (also in nested serializers) are automatically added to it. What is the use case for manually specifying additional options? The following works fine:

    ```ruby
    class AuthorSerializer < LightweightSerializer::Serializer
      attribute :name, condition: :admin
    end
    
    # Condition is false, no `name`.
    AuthorSerializer.new({name: 'test'}).as_json
    => {:data=>{:type=>"hash"}}
    
    # Condition is true, `name` is present.
    AuthorSerializer.new({name: 'test'}, admin: true).as_json
    => {:data=>{:name=>"test", :type=>"hash"}}
    
    class PostSerializer < LightweightSerializer::Serializer
      nested :author, serializer: AuthorSerializer
    end
    
    # Condition is true and passed to parent serializer: still passed along to child serializer.
    PostSerializer.new({author: {name: 'test'}}, admin: true).as_json
    => {:data=>{:author=>{:name=>"test", :type=>"hash"}, :type=>"hash"}}
    
    # If condition is false, it's also passed correctly to the child serializer.
    PostSerializer.new({author: {name: 'test'}}).as_json
    => {:data=>{:author=>{:type=>"hash"}, :type=>"hash"}}
    ```

* It probably would be good to document the use case of the OpenAPI feature. I usually write the OpenAPI specification first, and then translate it to code. With the serializers, we document the attributes within the serializer and then generate the object specification from it. Where is that specification then used? Is it fed to some automated process? For me personally, it's easier to document the objects in an OpenAPI editor than in code (where I have to look up option values etc. without a GUI).