### PR TITLE
Ignore unrecognized Rubocop cops

### DIFF
--- a/.rubocop
+++ b/.rubocop
@@ -1,0 +1,1 @@
+--ignore-unrecognized-cops


### PR DESCRIPTION
I don't know how to add the flag to the CI workflow. It uses rake instead of explicitly calling rubocop. I suspect, this command-line option should be enough though.