### PR TITLE
Update rubies used on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7.5'
-          - '3.0.3'
-          - '3.1.2'
-          - '3.2.1'
+          - '2.7.8'
+          - '3.0.6'
+          - '3.1.4'
+          - '3.2.2'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
2.7.8 is the last version of the 2.7 branch that will see a release, so we likely can get rid of it once dependent projects have updates their rubies.

3.0 just moved into the security maintenance phase, and will EOL within a year.

3.1 & 3.2 have been updated to their latest security releases.